### PR TITLE
fix: remove httpOnly option on cookies set

### DIFF
--- a/src/config/testUtils/expects.tsx
+++ b/src/config/testUtils/expects.tsx
@@ -23,7 +23,6 @@ export function expectFunctionNotToHaveBeenCalledWith(fn: any, value: any) {
 
 export function expectCookieToHaveBeenSet(key: string, value: string) {
   return expect(mockCookieSet).toHaveBeenCalledWith(key, value, {
-    httpOnly: true,
     sameSite: "strict",
     secure: true,
   });

--- a/src/lib/cookies/index.ts
+++ b/src/lib/cookies/index.ts
@@ -1,12 +1,9 @@
 import Cookies from "js-cookie";
 
-const isHttpsEnv = process.env.NODE_ENV !== "development";
-
 export function setCookiesItem(key: string, value: string): void {
   Cookies.set(key, value, {
     secure: true,
     sameSite: "strict",
-    httpOnly: isHttpsEnv,
   });
 }
 
@@ -18,6 +15,5 @@ export function removeCookiesItem(key: string) {
   Cookies.remove(key, {
     secure: true,
     sameSite: "strict",
-    httpOnly: isHttpsEnv,
   });
 }


### PR DESCRIPTION
<!-- Delete any of those topics if they don't fit -->
[js-cookie about httpOnly prop](https://github.com/js-cookie/js-cookie/wiki/Frequently-Asked-Questions)
# Description

- Remove httpOnly prop since it can lead to the cookie not being set

# Necessary changes

- Put here any changes that must be done when this PR is merged
- eg: update an environment variable

## Does this pull request close any open issues?

- Put here the issue that must be closed with this PR
- eg: closes #111

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] It is urgent
- [ ] <span style="color:#d44037">Dangerous change</span>
